### PR TITLE
registration endpoints for testing

### DIFF
--- a/backend/controller/pycon_registration_controller.py
+++ b/backend/controller/pycon_registration_controller.py
@@ -1,5 +1,5 @@
 from http import HTTPStatus
-from typing import List
+from typing import List, Optional
 
 from aws.cognito_settings import AccessUser, get_current_user
 from constants.common_constants import CommonConstants
@@ -181,7 +181,7 @@ def get_registration_by_email(
 )
 def get_registrations(
     event_id: str = Query(None, title='Event Id', alias=CommonConstants.EVENT_ID),
-    is_delted: bool = Query(False, title='Include deleted entries', alias='isDeleted'),
+    is_deleted: Optional[bool] = Query(None, title='Include deleted entries', alias='isDeleted'),
     current_user: AccessUser = Depends(get_current_user),
 ):
     """
@@ -189,7 +189,7 @@ def get_registrations(
     """
     _ = current_user
     registrations_uc = PyconRegistrationUsecase()
-    return registrations_uc.get_pycon_registrations(event_id=event_id, is_deleted=is_delted)
+    return registrations_uc.get_pycon_registrations(event_id=event_id, is_deleted=is_deleted)
 
 
 @pycon_registration_router.get(

--- a/backend/controller/pycon_registration_controller.py
+++ b/backend/controller/pycon_registration_controller.py
@@ -181,6 +181,7 @@ def get_registration_by_email(
 )
 def get_registrations(
     event_id: str = Query(None, title='Event Id', alias=CommonConstants.EVENT_ID),
+    is_delted: bool = Query(False, title='Include deleted entries', alias='isDeleted'),
     current_user: AccessUser = Depends(get_current_user),
 ):
     """
@@ -188,7 +189,7 @@ def get_registrations(
     """
     _ = current_user
     registrations_uc = PyconRegistrationUsecase()
-    return registrations_uc.get_pycon_registrations(event_id=event_id)
+    return registrations_uc.get_pycon_registrations(event_id=event_id, is_deleted=is_delted)
 
 
 @pycon_registration_router.get(

--- a/backend/model/registrations/registration.py
+++ b/backend/model/registrations/registration.py
@@ -101,6 +101,8 @@ class Registration(Model):
 
     validIdObjectKey = UnicodeAttribute(null=True)
 
+    deletedAt = UnicodeAttribute(null=True)
+
 
 class RegistrationDataIn(BaseModel):
     class Config:

--- a/backend/repository/registrations_repository.py
+++ b/backend/repository/registrations_repository.py
@@ -101,21 +101,21 @@ class RegistrationsRepository:
 
         """
         try:
+            condition = None
+            if not is_deleted:
+                condition = Registration.entryStatus == EntryStatus.ACTIVE.value
+
             if event_id is None:
                 registration_entries = list(
                     Registration.scan(
-                        filter_condition=Registration.entryStatus == EntryStatus.ACTIVE.value
-                        if not is_deleted
-                        else None,
+                        filter_condition=condition,
                     )
                 )
             else:
                 registration_entries = list(
                     Registration.query(
                         hash_key=event_id,
-                        filter_condition=Registration.entryStatus == EntryStatus.ACTIVE.value
-                        if not is_deleted
-                        else None,
+                        filter_condition=condition,
                     )
                 )
 

--- a/backend/usecase/pycon_registration_usecase.py
+++ b/backend/usecase/pycon_registration_usecase.py
@@ -294,14 +294,13 @@ class PyconRegistrationUsecase:
             status,
             registrations,
             message,
-        ) = self.__registrations_repository.query_registrations(event_id=event_id)
+        ) = self.__registrations_repository.query_registrations(event_id=event_id, is_deleted=is_deleted)
         if status != HTTPStatus.OK:
             return JSONResponse(status_code=status, content={'message': message})
 
         return [
             self.collect_pre_signed_url_pycon(PyconRegistrationOut(**self.__convert_data_entry_to_dict(registration)))
             for registration in registrations
-            if (not registration.deletedAt or is_deleted)
         ]
 
     def get_pycon_registration_csv(self, event_id: str) -> FileDownloadOut:

--- a/backend/usecase/pycon_registration_usecase.py
+++ b/backend/usecase/pycon_registration_usecase.py
@@ -274,7 +274,9 @@ class PyconRegistrationUsecase:
 
         return self.collect_pre_signed_url_pycon(registration_out)
 
-    def get_pycon_registrations(self, event_id: str = None) -> Union[JSONResponse, List[PyconRegistrationOut]]:
+    def get_pycon_registrations(
+        self, event_id: str = None, is_deleted: bool = False
+    ) -> Union[JSONResponse, List[PyconRegistrationOut]]:
         """Retrieves a list of PyCon registration entries.
 
         :param event_id: If provided, only retrieves registration entries for the specified event. If not provided, retrieves all registration entries.
@@ -299,6 +301,7 @@ class PyconRegistrationUsecase:
         return [
             self.collect_pre_signed_url_pycon(PyconRegistrationOut(**self.__convert_data_entry_to_dict(registration)))
             for registration in registrations
+            if (not registration.deletedAt or is_deleted)
         ]
 
     def get_pycon_registration_csv(self, event_id: str) -> FileDownloadOut:

--- a/backend/usecase/registration_usecase.py
+++ b/backend/usecase/registration_usecase.py
@@ -11,10 +11,6 @@ from model.events.event import Event
 from model.events.events_constants import EventStatus
 from model.file_uploads.file_upload import FileDownloadOut
 from model.konfhub.konfhub import KonfHubCaptureRegistrationIn, RegistrationDetail
-from model.pycon_registrations.pycon_registration import (
-    PyconRegistrationOut,
-    PyconRegistrationPatch,
-)
 from model.registrations.registration import (
     PreRegistrationToRegistrationIn,
     RegistrationIn,
@@ -246,8 +242,8 @@ class RegistrationUsecase:
         return self.collect_pre_signed_url(registration_out)
 
     def update_registration(
-        self, event_id: str, registration_id: str, registration_in: PyconRegistrationPatch
-    ) -> Union[JSONResponse, PyconRegistrationOut]:
+        self, event_id: str, registration_id: str, registration_in: RegistrationIn
+    ) -> Union[JSONResponse, RegistrationOut]:
         """Updates an existing registration entry.
 
         :param registration_id: The unique identifier of the registration to be updated.
@@ -284,10 +280,10 @@ class RegistrationUsecase:
             return JSONResponse(status_code=status, content={'message': message})
 
         registration_data = self.__convert_data_entry_to_dict(update_registration)
-        registration_out = PyconRegistrationOut(**registration_data)
+        registration_out = RegistrationOut(**registration_data)
         return self.collect_pre_signed_url(registration_out)
 
-    def get_registration(self, event_id: str, registration_id: str) -> Union[JSONResponse, PyconRegistrationOut]:
+    def get_registration(self, event_id: str, registration_id: str) -> Union[JSONResponse, RegistrationOut]:
         """Retrieves a specific registration entry by its ID.
 
         :param event_id: The ID of the event
@@ -316,7 +312,7 @@ class RegistrationUsecase:
             return JSONResponse(status_code=status, content={'message': message})
 
         registration_data = self.__convert_data_entry_to_dict(registration)
-        registration_out = PyconRegistrationOut(**registration_data)
+        registration_out = RegistrationOut(**registration_data)
         return self.collect_pre_signed_url(registration_out)
 
     def get_registration_by_email(self, event_id: str, email: str) -> RegistrationOut:
@@ -348,7 +344,7 @@ class RegistrationUsecase:
 
     def get_registrations(
         self, event_id: str = None, is_deleted: bool = False
-    ) -> Union[JSONResponse, List[PyconRegistrationOut]]:
+    ) -> Union[JSONResponse, List[RegistrationOut]]:
         """Retrieves a list of registration eregistration_idntries.
 
         :param event_id: If provided, only retrieves registration entries for the specified event. If not provided, retrieves all registration entries.
@@ -366,14 +362,13 @@ class RegistrationUsecase:
             status,
             registrations,
             message,
-        ) = self.__registrations_repository.query_registrations(event_id=event_id)
+        ) = self.__registrations_repository.query_registrations(event_id=event_id, is_deleted=is_deleted)
         if status != HTTPStatus.OK:
             return JSONResponse(status_code=status, content={'message': message})
 
         return [
-            self.collect_pre_signed_url(PyconRegistrationOut(**self.__convert_data_entry_to_dict(registration)))
+            self.collect_pre_signed_url(RegistrationOut(**self.__convert_data_entry_to_dict(registration)))
             for registration in registrations
-            if (not registration.deletedAt or is_deleted)
         ]
 
     def get_registration_csv(self, event_id: str) -> FileDownloadOut:
@@ -466,7 +461,7 @@ class RegistrationUsecase:
 
         return registration
 
-    def collect_pre_signed_url_pycon(self, registration: PyconRegistrationOut) -> PyconRegistrationOut:
+    def collect_pre_signed_url_pycon(self, registration: RegistrationOut) -> RegistrationOut:
         """Collects the pre-signed URL for the valid ID image.
 
         :param registration: The registration entry to be updated.

--- a/backend/usecase/registration_usecase.py
+++ b/backend/usecase/registration_usecase.py
@@ -12,7 +12,6 @@ from model.events.events_constants import EventStatus
 from model.file_uploads.file_upload import FileDownloadOut
 from model.konfhub.konfhub import KonfHubCaptureRegistrationIn, RegistrationDetail
 from model.pycon_registrations.pycon_registration import (
-    PyconRegistrationIn,
     PyconRegistrationOut,
     PyconRegistrationPatch,
 )


### PR DESCRIPTION
- updated usecases for new pycon endpoints
- GET /pycon/registrations with isDeleted as false returns all registrations that are not soft deleted unless isDeleted is true which returns every registration regardless if it is deleted.
- Delete /pycon/registration/entry_id now performs soft delete, updating deletedAt and entryStatus